### PR TITLE
Support creating Github objects by passing only a token

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,16 @@ can read the docs and immediately know how to do the examples via
 ## Example App
 
 1. First, instantiate a `Github` object, passing it your username and
-   password if an authenticated session is desired.
+   password or a token if an authenticated session is desired.
 
    ```python
    >>> from agithub import Github
    >>> g = Github('user', 'pass')
+   ```
+
+   ```python
+   >>> from agithub import Github
+   >>> g = Github(token='token')
    ```
 
 2. When you make a request, the status and response body are passed back

--- a/agithub_test.py
+++ b/agithub_test.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+import agithub
+import unittest
+
+class TestGithubObjectCreation(unittest.TestCase):
+    def test_user_pw(self):
+        gh = agithub.Github('korfuri', '1234')
+        self.assertTrue(gh is not None)
+
+        gh = agithub.Github(username='korfuri', password='1234')
+        self.assertTrue(gh is not None)
+
+    def test_token(self):
+        gh = agithub.Github(username='korfuri', token='deadbeef')
+        self.assertTrue(gh is not None)
+
+        gh = agithub.Github(token='deadbeef')
+        self.assertTrue(gh is not None)
+
+    def test_token_password(self):
+        with self.assertRaises(TypeError):
+            gh = agithub.Github(
+                username='korfuri', password='1234', token='deadbeef')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Issue #11 sums it up: you need to pass a username to create a Github object, even if you're using a token. This doesn't make much sense when using OAuth. This PR fixes this, adds a test to ensure it works, and updates README.md accordingly.
