### PR TITLE
Rename RequestBuilder to IncompleteRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ can read the docs and immediately know how to do the examples via
 
    ```python
    >>> g.issues
-   <class 'agithub.github.RequestBuilder'>: I don't know about /issues
+   <class 'agithub.github.IncompleteRequest'>: /issues
    ```
 
 4. Sometimes, it is inconvenient (or impossible) to refer to a URL as a

--- a/agithub.py
+++ b/agithub.py
@@ -47,11 +47,11 @@ class API(object):
         self.client.setConnectionProperties(props)
 
     def __getattr__(self, key):
-        return RequestBuilder(self.client).__getattr__(key)
+        return IncompleteRequest(self.client).__getattr__(key)
     __getitem__ = __getattr__
 
     def __repr__(self):
-        return RequestBuilder(self.client).__repr__()
+        return IncompleteRequest(self.client).__repr__()
 
     def getheaders(self):
         return self.client.headers
@@ -94,14 +94,15 @@ class Github(API):
         self.setClient(Client(*args, **kwargs))
         self.setConnectionProperties(props)
 
-class RequestBuilder(object):
-    '''RequestBuilders build HTTP requests via an HTTP-idiomatic notation,
+class IncompleteRequest(object):
+    '''IncompleteRequests are partially-built HTTP requests.
+    They can be built via an HTTP-idiomatic notation,
     or via "normal" method calls.
 
     Specifically,
-    >>> RequestBuilder(client).path.to.resource.METHOD(...)
+    >>> IncompleteRequest(client).path.to.resource.METHOD(...)
     is equivalent to
-    >>> RequestBuilder(client).client.METHOD('path/to/resource', ...)
+    >>> IncompleteRequest(client).client.METHOD('path/to/resource', ...)
     where METHOD is replaced by get, post, head, etc.
 
     Also, if you use an invalid path, too bad. Just be ready to catch a
@@ -129,10 +130,7 @@ class RequestBuilder(object):
     __getitem__ = __getattr__
 
     def __str__(self):
-        '''If you ever stringify this, you've (probably) messed up
-        somewhere. So let's give a semi-helpful message.
-        '''
-        return "I don't know about " + self.url
+        return self.url
 
     def __repr__(self):
         return '%s: %s' % (self.__class__, self.url)

--- a/agithub_test.py
+++ b/agithub_test.py
@@ -24,30 +24,30 @@ class TestGithubObjectCreation(unittest.TestCase):
                 username='korfuri', password='1234', token='deadbeef')
 
 
-class TestRequestBuilder(unittest.TestCase):
+class TestIncompleteRequest(unittest.TestCase):
 
-    def newRequestBuilder(self):
-        return agithub.RequestBuilder(mock.Client())
+    def newIncompleteRequest(self):
+        return agithub.IncompleteRequest(mock.Client())
 
     def test_pathByGetAttr(self):
-        rb = self.newRequestBuilder()
+        rb = self.newIncompleteRequest()
         rb.hug.an.octocat
         self.assertEqual(rb.url, "/hug/an/octocat")
 
     def test_callMethodDemo(self):
-        rb = self.newRequestBuilder()
+        rb = self.newIncompleteRequest()
         self.assertEqual(rb.path.demo(),
                 { "methodName" : "demo"
                 , "args" : ()
                 , "params" : { "url" : "/path" }
                 })
     def test_pathByGetItem(self):
-        rb = self.newRequestBuilder()
+        rb = self.newIncompleteRequest()
         rb["hug"][1]["octocat"]
         self.assertEqual(rb.url, "/hug/1/octocat")
 
     def test_callMethodDemo(self):
-        rb = self.newRequestBuilder()
+        rb = self.newIncompleteRequest()
         self.assertEqual(rb.path.demo(),
                 { "methodName" : "demo"
                 , "args" : ()
@@ -55,7 +55,7 @@ class TestRequestBuilder(unittest.TestCase):
                 })
 
     def test_callMethodTest(self):
-        rb = self.newRequestBuilder()
+        rb = self.newIncompleteRequest()
         self.assertEqual(rb.path.test(),
                 { "methodName" : "test"
                 , "args" : ()


### PR DESCRIPTION
Now instead of

```
>>> g.issues
<class 'agithub.github.RequestBuilder'>: I don't know about /issues
```

you get

```
>>> g.issues
<class 'agithub.github.IncompleteRequest'>: /issues
```

The new wording is appropriate both as an error message (we see it is incomplete!) and in logs (yeah we wanted to see the URL being constructed).
(The guiding principle I used: "Just state the facts, let the reader derive value judgements from that.")
