### PR TITLE
Support GitHub Enterprise instances

### DIFF
--- a/agithub.py
+++ b/agithub.py
@@ -84,7 +84,7 @@ class Github(API):
     '''
     def __init__(self, *args, **kwargs):
         props = ConnectionProperties(
-                    api_url = 'api.github.com',
+                    api_url = kwargs.pop('api_url', 'api.github.com'),
                     secure_http = True,
                     extra_headers = {
                         'accept' :    'application/vnd.github.v3+json'


### PR DESCRIPTION
This allows easy customization of the API root URL, so the user could connect to an Enterprise instance like this:

``` py
ent = Github(username='xrd', password='foobar', api_url='github.corp.ebay.com')
```
