### PR TITLE
Fix for error with funMangledMediaType and RequestBody ignoring mtype from headers

### DIFF
--- a/agithub/base.py
+++ b/agithub/base.py
@@ -339,8 +339,7 @@ class RequestBody(Body):
     def __init__(self, body, headers):
         self.body = body
         self.headers = headers
-        self.parseContentType(
-                getattr(self.headers, 'content-type', None))
+        self.parseContentType(self.headers.get('content-type', None))
         self.encoding = self.ctypeParameters['charset']
 
     def encodeBody(self):
@@ -359,7 +358,7 @@ class RequestBody(Body):
         if self.body is None:
             return None
 
-        handlerName = self.funMangledMediaType()
+        handlerName = self.mangled_mtype()
         handler = getattr(  self, handlerName,
                             self.application_octet_stream
                             )


### PR DESCRIPTION
- Changed RequestBody.process() to use Body.mangled_mtype() instead of self.funMangledMediaType. This brings it in line with ReposnseBody.
- Changed RequestBody init call to parseContentType to use dict.get() instead of getattr to avoid passing None regardless of headers. The functionality remains the same, it will default to None if no content-type header is found. 
