### PR TITLE
Unauthenticated mode for GitHub

### DIFF
--- a/agithub/GitHub.py
+++ b/agithub/GitHub.py
@@ -30,12 +30,14 @@ class GitHub(API):
     it automatically supports the full API--so why should you care?
     '''
     def __init__(self, username=None, password=None, token=None, *args, **kwargs):
+        extraHeaders = {'accept' : 'application/vnd.github.v3+json'}
+        auth = self.generateAuthHeader(username, password, token)
+        if auth != None:
+            extraHeaders['authorization'] = auth
         props = ConnectionProperties(
                     api_url = kwargs.pop('api_url', 'api.github.com'),
                     secure_http = True,
-                    extra_headers = {
-                        'accept' : 'application/vnd.github.v3+json',
-                        'authorization' : self.generateAuthHeader(username, password, token)
+                    extra_headers = extraHeaders
                     })
 
         self.setClient(Client(*args, **kwargs))


### PR DESCRIPTION
If `GitHub()` is called with no username/password-pair and no token, don't add `authorization=None` to headers.
