### PR TITLE
Cherry pick from "next" branch

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,6 +24,23 @@ Upcoming
 Unscheduled
 -----------
 
+
+* Support reusing TCP connections, and "pipelining" of requests, a la
+  RFC 2068, Sect 8.1, L2377
+
+    - The user must ask for pipelining, and supply a callback function
+      to be called after a response is received.
+    - Rename Client.request() -> Client.addRequest() (or such)
+    - Have Client.addRequest() check whether a persistent connection is
+      wanted, and save the entire request in a Client.pendingRequests
+      list in that case
+    - Create a new Client.sendRequests() method which the user may call
+      to send all requests up the pipeline. (It should work even if the
+      server does not support pipelining)
+    - Call the user-supplied callback whenever a request is received.
+      There are some concurrency issues here, and we may elect to call
+      the callback only after *all* requests are received.
+
 * Create a script to pack the basic module and any given set of
   service-specific classes as one file. I still like the idea that a
   given API (e.g. Facebook) could be packed into a single file, and
@@ -81,6 +98,10 @@ v2.0
 * Bugfixes:
     - Use `application/octet-stream` for unknown media type
     - Spell 'GitHub' correctly
+
+* Parse Content-Type header correctly; make a dict of the
+  parameters (Content.ctypeParameters) available to the media-type
+  handlers
 
 v1.3
 ----

--- a/agithub/GitHub.py
+++ b/agithub/GitHub.py
@@ -46,7 +46,7 @@ class GitHub(API):
     def generateAuthHeader(self, username=None, password=None, token=None):
         if token is not None:
             if password is not None:
-                raise TypeError("You cannot use both password and oauth token authenication")
+                raise TypeError("You cannot use both password and OAuth token authentication")
             return 'Token %s' % token
         elif username is not None:
             if password is None:

--- a/agithub/base.py
+++ b/agithub/base.py
@@ -5,6 +5,7 @@ import base64
 import re
 from functools import partial, update_wrapper
 
+import xml.dom.minidom
 
 import sys
 if sys.version_info[0:2] > (3,0):
@@ -322,6 +323,22 @@ class ResponseBody(Body):
     text_javascript = application_json
     # XXX: This isn't technically correct, but we'll hope for the best.
     # Patches welcome!
+
+    def application_xml(self):
+        self.decode_body()
+
+        try:
+            pybody = xml.dom.minidom.parseString(self.body)
+        except Exception: #TODO: What kind of exceptions?
+            pybody = self.body
+
+        return pybody
+
+
+    text_xml = application_xml
+    # The difference between text/xml and application/xml is whether it
+    # is human-readable or not. For our purposes, there is no
+    # difference. RFC 3023, L270.
 
     # Insert new Response media-type handlers here
 

--- a/agithub/base.py
+++ b/agithub/base.py
@@ -136,12 +136,6 @@ class Client(object):
             self.default_headers.update(prop.extra_headers)
         self.prop = prop
 
-        # Enforce case restrictions on self.default_headers
-        tmp_dict = {}
-        for k,v in self.default_headers.items():
-            tmp_dict[k.lower()] = v
-        self.default_headers = tmp_dict
-
     def head(self, url, headers={}, **params):
         url += self.urlencode(params)
         return self.request('HEAD', url, None, headers)
@@ -210,7 +204,7 @@ class Client(object):
         # Add default headers (if unspecified)
         for k,v in self.default_headers.items():
             if k not in headers:
-                headers[k] = v
+                headers[k.lower()] = v
         return headers
 
     def urlencode(self, params):

--- a/agithub/base.py
+++ b/agithub/base.py
@@ -292,7 +292,7 @@ class ResponseBody(Body):
 
     def processBody(self):
         '''
-        Retrieve the body of the response, encoding it into a usuable
+        Retrieve the body of the response, encoding it into a usable
         form based on the media-type (mime-type)
         '''
         handlerName = self.mangled_mtype()
@@ -323,7 +323,7 @@ class ResponseBody(Body):
     # XXX: This isn't technically correct, but we'll hope for the best.
     # Patches welcome!
 
-    # Insert new media-type handlers here
+    # Insert new Response media-type handlers here
 
 class RequestBody(Body):
     '''

--- a/agithub/base.py
+++ b/agithub/base.py
@@ -131,9 +131,9 @@ class Client(object):
         if type(prop) is not ConnectionProperties:
             raise TypeError("Client.setConnectionProperties: Expected ConnectionProperties object")
 
+        self.default_headers = _default_headers.copy()
         if prop.extra_headers is not None:
             prop.filterEmptyHeaders()
-            self.default_headers = _default_headers.copy()
             self.default_headers.update(prop.extra_headers)
         self.prop = prop
 

--- a/agithub/base.py
+++ b/agithub/base.py
@@ -169,7 +169,7 @@ class Client(object):
     def patch(self, url, body=None, headers={}, **params):
         """
         Do a http patch request on the given url with given body, headers and parameters
-        Parameters is a dictionary that will will be urlencoded
+        Parameters is a dictionary that will will be url-encoded
         """
         url += self.urlencode(params)
         if not 'content-type' in headers:

--- a/agithub/test.py
+++ b/agithub/test.py
@@ -1,4 +1,5 @@
-# Copyright 2012-2016 Jonathan Paugh and contributors
+#!/usr/bin/env python3
+#  Copyright 2012-2016 Jonathan Paugh and contributors
 # See COPYING for license details
 from __future__ import print_function
 from agithub.GitHub import GitHub


### PR DESCRIPTION
This is a hand review of the 18 commits in the #44 `next` branch. The commits are a combination of 

* code that made it into `master` through another means
* code that we don't want from `next`
* code that we may want from `next` that I've rendered into 7 new commits. Some of these have been reformulated to work with the current codebase or modified to strip out things which move us farther from PEP008

We should review the functionality in this PR and if it's desired, merge it and throw away #44 and the `next` branch.

* Ignoring 996e6105df8dd11207baf0a0143ab37c511ce1aa as it moves away from PEP008
* Ignoring 6c77aabe125df177099147b53046e6f874408d5e as it was added to master in f835846b73de63c439efce59296b6cab3a5518c0
* Ignoring 29d4f149aaff02ef160aecf3268ce94a054d8fca as it's a version bump
* Rendering 54b4b08d49c0e472b9a51f308a1ea0309d3bb691 in new PR as d7575dc45657046f4d5a3a4e2c84a42aa4c541ed : Spelling fix
* Rendering 079976b5aca01747aa79e2fd3a3d1f915d183f7e in new PR as 2ed2abe134868f2575d193531e4c129ca583a0a4 : Refactoring duplicate code so it's called once
* Ignoring 90da9d24a105f42e945be2d6b1d2bf176d197ee2 as it is a change to the order of future planned work in the changelog
* Ignoring 0a3f4787ef68d7eb12b25d7708ccecb2f9c41789 as it is planned work in v 2.0 in the Changelog
* Ignoring 958ceee6255eb4002e7502211a987d925757961f as it was added to master in 731b6129260b2acb49e18da5ce550c0c1e68873c with a small exception of one variable name which I'm gonna leave
* Ignoring 769790999274779bbb690a1263da163c7ed0dfd3 as it was added to master in cbb028814321aa1757a6164b3a0fc47ec5aa176d
* Ignoring 28f5a31cc32ff297a481e4b7f0699ff04d253c1a as it was added to master in 7c02d0c0cd1e8e6d5793a14579fc43f54cae2c7b
* Ignoring ff6c0e89ab8e38569a5b758ce057a5ba67404288 as it was added to master in 8a444206679c74063c2871dc0f667947c48e0f36
* Ignoring f0f09ac3a0f6119b84c7af4ae0cd98664faae553 as it was added to master in ea6191a1c3a3dce17e9c435fe6800c34cf843b3c
* Rendering fad02faaf393c54d23a65b1a0220840669af9011 in a new PR as 90c69b85ac7efb15d8c3f535b8d64ece32d3489a : Spelling fix
* Rendering 51f5b78a08b650b12d6dffacce3d1b27a5c8d650 in a new PR as 2db5876edde8d7579ca6634cd86ee552d55bd7b2 : add line to make test.py executable
* Rendering 6a44c59509ecb9486b14f73551c66a4dfc2f07d6 in a new PR as 5f61c3ece21d4e2e8f7799af6edc703f886a0a84 : Changelog addition
* Ignoring e9cd78dc203a0f5b0b772b88937b152a8073f601 as it was added to master in a84c16fc32d40a10743ed51653c7e51b58067f19
* Rendering 3d373435c8110612cad061e9a9b31a7a1abd752c in a new PR as 74b49d20fc24b54b07094a2c086e1e758dcc73ab : Add a media-type handler for XML
* Rendering e1143ed97638f18ccb17f7c409641100ffa58f92 in a new PR as 0706cfe0199ba54b0acc0f46c280a56f96797cb3 : Bugfix