### PR TITLE
Revert a few auto formatted comments and code structures

### DIFF
--- a/agithub/Facebook.py
+++ b/agithub/Facebook.py
@@ -14,8 +14,7 @@ class Facebook(API):
     >>> fb.facebook.picture.get(redirect='false')
     {u'data': {u'is_silhouette': False,
        u'url':
-           u'https://fbcdn-profile-a.akamaihd.net/hprofile-ak-frc3/
-           t1.0-1/p50x50/1377580_10152203108461729_809245696_n.png'}})
+           u'https://fbcdn-profile-a.akamaihd.net/hprofile-ak-frc3/t1.0-1/p50x50/1377580_10152203108461729_809245696_n.png'}})
     """
     def __init__(self, *args, **kwargs):
         props = ConnectionProperties(

--- a/agithub/SalesForce.py
+++ b/agithub/SalesForce.py
@@ -8,9 +8,7 @@ class SalesForce(API):
     SalesForce.com REST API
 
     Example taken from
-    http://www.salesforce.com/us/developer/docs/api_rest/
-    index_Left.htm#CSHID=quickstart_code.htm|
-    StartTopic=Content%2Fquickstart_code.htm|SkinName=webhelp
+    http://www.salesforce.com/us/developer/docs/api_rest/index_Left.htm#CSHID=quickstart_code.htm|StartTopic=Content%2Fquickstart_code.htm|SkinName=webhelp
 
     >>> from SalesForce import SalesForce
     >>> sf = SalesForce()

--- a/agithub/test.py
+++ b/agithub/test.py
@@ -44,21 +44,14 @@ class Test(object):
                 raise ValueError('Bad test result ' + (res))
 
         print(
-            '\n'
-            ' Results\n'
-            '--------------------------------------\n'
-            'Tests Run:     ',
-            len(results),
-            '\n'
-            '      Passed:  ',
-            passes,
-            '\n'
-            '      Failed:  ',
-            fails,
-            '\n'
-            '      Skipped: ',
-            skips
-        )
+                '\n'
+                ' Results\n'
+                '--------------------------------------\n'
+                'Tests Run:     ', len(results), '\n'
+                '      Passed:  ', passes, '\n'
+                '      Failed:  ', fails, '\n'
+                '      Skipped: ', skips
+            )
 
     def runTest(self, test, api):
         """Run a single test with the given API session"""


### PR DESCRIPTION
Some of code changes in #38 were done by software and it broke a few URLs in docstrings
as well as reformatting a columnar printout.
This reverts those back