### PR TITLE
Revert move to SCM driven version number derived from VCS and back to hard coded version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.2] - 2019-10-07
+### Fixed
+* Reverted the move to using setuptools-scm as it's [not actually meant to be
+  used in the package code, only in setup.py](https://github.com/pypa/setuptools_scm/issues/354#issuecomment-519407730).
+  setuptools-scm was causing an `LookupError: setuptools-scm was unable to detect version` error
+
 ## [2.2.1] - 2019-10-07
 ### Added
 * Mozilla code of conduct
@@ -89,7 +95,8 @@ contributed!)
 * Has a version number. (Yippie!)
 * First more-or-less stable version
 
-[Unreleased]: https://github.com/mozilla/agithub/compare/v2.2.1...HEAD
+[Unreleased]: https://github.com/mozilla/agithub/compare/v2.2.2...HEAD
+[2.2.2]: https://github.com/mozilla/agithub/compare/v2.2.1...v2.2.2
 [2.2.1]: https://github.com/mozilla/agithub/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/mozilla/agithub/compare/v2.1...v2.2.0
 [2.1]: https://github.com/mozilla/agithub/compare/v2.0...v2.1

--- a/agithub/__init__.py
+++ b/agithub/__init__.py
@@ -1,5 +1,5 @@
 # Copyright 2012-2016 Jonathan Paugh and contributors
 # See COPYING for license details
-from agithub.base import VERSION
+from agithub.base import VERSION, STR_VERSION
 
-__all__ = ["VERSION"]
+__all__ = ["VERSION", "STR_VERSION"]

--- a/agithub/base.py
+++ b/agithub/base.py
@@ -2,7 +2,6 @@
 # See COPYING for license details
 import json
 from functools import partial, update_wrapper
-from setuptools_scm import get_version
 
 import sys
 if sys.version_info[0:2] > (3, 0):
@@ -15,13 +14,14 @@ else:
     class ConnectionError(OSError):
         pass
 
-VERSION = get_version(root='..', relative_to=__file__)
+VERSION = [2, 2, 2]
+STR_VERSION = 'v' + '.'.join(str(v) for v in VERSION)
 
 # These headers are implicitly included in each request; however, each
 # can be explicitly overridden by the client code. (Used in Client
 # objects.)
 _default_headers = {
-    'user-agent': 'agithub/' + VERSION,
+    'user-agent': 'agithub/' + STR_VERSION,
     'content-type': 'application/json'
 }
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[egg_info]
+tag_build =
+tag_date = 0
+tag_svn_revision = 0
+

--- a/setup.py
+++ b/setup.py
@@ -5,13 +5,10 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.md')) as f:
     long_description = f.read()
 
-test_requirements = ['pytest']
-
-extras = {
-    "test": test_requirements,
-}
+version = '2.2.2'
 
 setup(name='agithub',
+      version=version,
       description="A lightweight, transparent syntax for REST clients",
       long_description=long_description,
       long_description_content_type='text/markdown',
@@ -32,9 +29,4 @@ setup(name='agithub',
       packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
       include_package_data=True,
       zip_safe=False,
-      tests_require=test_requirements,
-      extras_require=extras,
-      setup_requires=['setuptools-scm'],
-      use_scm_version=True,
-      install_requires=['setuptools-scm'],
       )


### PR DESCRIPTION
Change VERSION constant from string version (e.g. 2.2.1) back to semver list (e.g. [2, 2, 1])
Replace STR_VERSION constant
This reverts b189a1ecbd44022bb4348d823c3ae8a83b023f57
Also move to version 2.2.2