### PR TITLE
immutable IncompleteRequest.__getattr__

### DIFF
--- a/agithub/agithub_test.py
+++ b/agithub/agithub_test.py
@@ -57,8 +57,8 @@ class TestIncompleteRequest(unittest.TestCase):
 
     def test_pathByGetAttr(self):
         rb = self.newIncompleteRequest()
-        rb.hug.an.octocat
-        self.assertEqual(rb.url, "/hug/an/octocat")
+        test = rb.hug.an.octocat
+        self.assertEqual(test.url, "/hug/an/octocat")
 
     def test_callMethodDemo(self):
         rb = self.newIncompleteRequest()
@@ -73,8 +73,8 @@ class TestIncompleteRequest(unittest.TestCase):
 
     def test_pathByGetItem(self):
         rb = self.newIncompleteRequest()
-        rb["hug"][1]["octocat"]
-        self.assertEqual(rb.url, "/hug/1/octocat")
+        test = rb["hug"][1]["octocat"]
+        self.assertEqual(test.url, "/hug/1/octocat")
 
     def test_callMethodTest(self):
         rb = self.newIncompleteRequest()

--- a/agithub/base.py
+++ b/agithub/base.py
@@ -79,9 +79,9 @@ class IncompleteRequest(object):
 
     To understand the method(...) calls, check out github.client.Client.
     """
-    def __init__(self, client):
+    def __init__(self, client, url=""):
         self.client = client
-        self.url = ''
+        self.url = url
 
     def __getattr__(self, key):
         if key in self.client.http_methods:
@@ -89,8 +89,8 @@ class IncompleteRequest(object):
             wrapper = partial(htmlMethod, url=self.url)
             return update_wrapper(wrapper, htmlMethod)
         else:
-            self.url += '/' + str(key)
-            return self
+            new_url = self.url + '/' + str(key)
+            return IncompleteRequest(self.client, new_url)
 
     __getitem__ = __getattr__
 

--- a/setup.py
+++ b/setup.py
@@ -7,11 +7,19 @@ with open(path.join(here, 'README.md')) as f:
 
 version = '2.2.2'
 
+test_requirements = ['pytest']
+
+extras = {
+    "test": test_requirements,
+}
+
 setup(name='agithub',
       version=version,
       description="A lightweight, transparent syntax for REST clients",
       long_description=long_description,
       long_description_content_type='text/markdown',
+      tests_require=test_requirements,
+      extras_require=extras,
       classifiers=[
           'Development Status :: 5 - Production/Stable',
           'Environment :: Console',


### PR DESCRIPTION
The main discussion of the problem is in #74, but TLDR is that `IncompleteRequest.__getattr__` mutating and returning `self` makes a lot of use-cases needlessly complicated.

This is a breaking change.

fixes: #74 

I also fixed `setup.py` to actually work with the `tox` config. It looks like that used to be there but got rolled back as part of an unrelated set of changes.